### PR TITLE
fix for PHPUnit 5

### DIFF
--- a/src/Constraint/XmlMatchesXsd.php
+++ b/src/Constraint/XmlMatchesXsd.php
@@ -12,7 +12,8 @@
 
 namespace PhpCsFixer\PhpunitConstraintXmlMatchesXsd\Constraint;
 
-if (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
+if (!class_exists('\PHPUnit\Runner\Version')
+    || version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
     class_alias(XmlMatchesXsdForV5::class, XmlMatchesXsd::class);
 } elseif (version_compare(\PHPUnit\Runner\Version::id(), '8.0.0') < 0) {
     class_alias(XmlMatchesXsdForV7::class, XmlMatchesXsd::class);


### PR DESCRIPTION
The `class_alias` exists in `symfony/phpunit-bridge` but it is only in "require-dev", so this library can be used without.
