### PR TITLE
Fix very old stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,22 @@
-sudo: false
+dist: xenial
+os: linux
+
+language: php
 
 git:
-    depth: 1
+    depth: 10
 
 cache:
     directories:
         - $HOME/.composer
 
-language: php
-
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-    - 7.4
-    - nightly
-
 env:
     global:
-        - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-progress"
+        - DEFAULT_COMPOSER_FLAGS="--optimize-autoloader --no-interaction --no-progress"
         - COMPOSER_FLAGS=""
 
 stages:
+    - Fast Test
     - Static code analysis
     - Test
 
@@ -32,14 +25,7 @@ before_install:
     - phpenv config-rm xdebug.ini || return 0
 
     # Composer: boost installation
-    - composer global show -ND 2>&1 | grep "hirak/prestissimo" || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
-
-install:
-    - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
-    - composer info -D | sort
-
-script:
-    - vendor/bin/phpunit
+    - composer global show hirak/prestissimo -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
 
 jobs:
     include:
@@ -55,3 +41,32 @@ jobs:
                 - composer normalize -d ./dev-tools ./../composer.json --dry-run || travis_terminate 1
                 - dev-tools/vendor/bin/phpmd src,tests text ./dev-tools/phpmd.xml || travis_terminate 1
                 - dev-tools/vendor/bin/php-cs-fixer fix --diff --dry-run -v || travis_terminate 1
+
+        - &STANDARD_TEST_JOB
+            stage: Test
+            php: 7.0
+            install:
+                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - composer info -D | sort
+            script:
+                - vendor/bin/phpunit
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 5.6
+            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.1
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.2
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.3
+        -
+            <<: *STANDARD_TEST_JOB
+            stage: Fast Test
+            php: 7.4
+        -
+            <<: *STANDARD_TEST_JOB
+            php: nightly

--- a/src/Constraint/XmlMatchesXsd.php
+++ b/src/Constraint/XmlMatchesXsd.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\PhpunitConstraintXmlMatchesXsd\Constraint;
 
-if (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
+if (!class_exists('\PHPUnit\Runner\Version') || version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
     class_alias(XmlMatchesXsdForV5::class, XmlMatchesXsd::class);
 } elseif (version_compare(\PHPUnit\Runner\Version::id(), '8.0.0') < 0) {
     class_alias(XmlMatchesXsdForV7::class, XmlMatchesXsd::class);


### PR DESCRIPTION
Hi all,

This PR show that https://github.com/PHP-CS-Fixer/phpunit-constraint-xmlmatchesxsd/pull/12 doesn't solve the issue (using the tests from https://github.com/PHP-CS-Fixer/phpunit-constraint-xmlmatchesxsd/pull/13).
To fix we could add PHP8 support to https://github.com/PHPUnitGoodPractices/polyfill , however that has an hidden dependency on https://github.com/PHPUnitGoodPractices/Traits 
(which isn't listed in its composer file; see https://github.com/PHPUnitGoodPractices/polyfill/blob/master/src/PolyfillTrait.php#L14 and the repo competly lacks unit tests) so PHP8 support is needed there as well.

cc @keradus and @remicollet 